### PR TITLE
Yaml config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 secrets.sh
 config.sh
+config.yaml
 venv/
 twodata.json
 __pycache__

--- a/README.md
+++ b/README.md
@@ -25,24 +25,18 @@ source venv/bin/activate # or similar, for your shell (e.g. activate.fish)
 
 This is done by going to the new bot page for your slack workspace `https://<workspace-name>.slack.com/services/new/bot`
 Pick a username and create the bot user, then copy the api key...
-```
-cp secrets_example.sh secrets.sh
-editor secrets.sh # paste your API key in the obvious place
-```
-
- - Configure the bot
 
 ```
-cp config_example.sh config.sh
-editor config.sh # Pick your test keyword and your test command word
+cp config_example.yaml config.yaml
+editor config.yaml # paste your api key in the obvious place, and choose a keyword and command
 ```
 
  - Run the bot
 
-Running `./run.sh` will source `secrets.sh` and `config.sh` and then run the bot. Make sure you have activated the venv before running, or it will probably crash.
+Running `./run.sh` will activate the venv and run the bot.
 
 ## REST API
-You can get real-time access to the current two statistics via the provided REST API. It runs on `0.0.0.0:2222`. Below are the methods you can use:
+You can get real-time access to the current two statistics via the provided REST API. It runs on `0.0.0.0:2222` by default, but you can change this in the config (or disable it entirely). Below are the methods you can use:
 
 ### GET /ids
 Returns JSON array of *user IDs* for all the users tracked by two-bot (any user that has been two'd).

--- a/config_example.sh
+++ b/config_example.sh
@@ -1,3 +1,0 @@
-# Copy this to config.sh and set your own values
-export TWO_KEYWORD=3 # Test it with 3, use 2 for prod
-export TWO_COMMAND=!three

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -1,0 +1,18 @@
+# commented-out config options are in their default state, uncommment them to change
+
+# api token - keep this secret!
+slack_token: xoxb-...
+
+# keyword that the bot picks up on - use 3 for testing
+keyword: 3
+# command to bring up the leaderboard
+command: "!three"
+# file to store two data in
+#filename: twodata.json
+
+# enables the REST API
+api_enable: false
+# use 0.0.0.0 to listen on all interfaces
+# ports < 1024 require root (sudo) if running on Linux
+#api_address: 0.0.0.0
+#api_port: 2222

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -e git+git@github.com:danieljabailey/python-slackclient.git@master#egg=slackclient
 bottle
+pyyaml

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
-source secrets.sh
-source config.sh
-./two.py
+source venv/bin/activate
+python two.py

--- a/secrets_example.sh
+++ b/secrets_example.sh
@@ -1,2 +1,0 @@
-# Copy this to "secrets.sh" and fill in your API token
-export TWO_SLACK_API_TOKEN="xoxb-xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx"

--- a/two.py
+++ b/two.py
@@ -34,7 +34,7 @@ class TwoBot:
             self.API_ADDRESS = config.get("api_address", "0.0.0.0")
             self.API_PORT = config.get("api_port", 2222)
         except KeyError as e:
-            print("Config.json missing some values! {}".format(e))
+            print("Config.yaml missing some values! {}".format(e))
             exit(3)
 
         self.slack = SlackClient(self.SLACK_TOKEN)


### PR DESCRIPTION
Uses a (hardcoded) YAML file `config.yaml` to expose api key, command, keyword (that were previously done via environment variables) as well as data file and REST api host/port to the user. This also allows #1 to be resolved more easily in the future.

This is a **breaking change** for people using two-bot, and as such people will be notified when the bot fails to start that they must use the new config.yaml now.

(Recommend squash and merge)