### PR TITLE
Added bot uptime endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Returns information about when this user was last two'd, as JSON object:
  - `last`: timestamp of last two
 
 Will fail with `404 not found` if an ID is passed that doesn't match a user (Even if that user is in Slack).
+### GET /uptime
+Returns information about how long the application has been running, as JSON object:
+ - `starttime`: timestamp of when the application was started (UTC, in floating-point seconds)
+ - `starttime_s`: ISO representation of `starttime`
+ - `duration`: Seconds since `starttime` (floating-point)
 
 ## Licence
 

--- a/api.py
+++ b/api.py
@@ -2,6 +2,7 @@ from bottle import Bottle, response, HTTPError
 from threading import Thread
 from operator import itemgetter
 import time
+from datetime import datetime
 import json
 
 class API(Bottle):
@@ -16,6 +17,7 @@ class API(Bottle):
         self.route('/leaderboard', callback=self.leaderboard)
 
         self.route('/info/<user>', callback=self.info)
+        self.route('/uptime', callback=self.uptime);
 
     def start(self):
         self.thread.start()
@@ -118,3 +120,19 @@ class API(Bottle):
                         the IRC bridge or a Slack bot that's been two'd (rare)
         """
         return self.get_user(user)
+
+    def uptime(self):
+        """ GET /uptime
+            application/json
+
+            Returns information about how long the application has been running:
+                starttime: timestamp of when the application was started (UTC, in floating-point seconds)
+                starttime_s: ISO representation of starttime
+                duration: Seconds since starttime (floating-point)
+        """
+        print(self.bot.starttime)
+        return {
+            'starttime': self.bot.starttime.timestamp(),
+            'starttime_s': self.bot.starttime.isoformat(),
+            'duration': datetime.utcnow().timestamp() - self.bot.starttime.timestamp() # time.time() isn't reliably UTC in my testing
+        }

--- a/two.py
+++ b/two.py
@@ -50,6 +50,8 @@ class TwoBot:
                 if key not in self.twoinfo:
                     self.twoinfo[key] = {}
         if self.API_ENABLE:
+            self.starttime = datetime.utcnow()
+            print("{} {} {} starttime".format(self, type(self), self.starttime))
             self.api = API(self, host=self.API_ADDRESS, port=self.API_PORT)
             self.api.start()
 


### PR DESCRIPTION
Allows monitoring of how long the bot has been online. Under GET /uptime.