### PR TITLE
Fix crash on "!two @<user>"

### DIFF
--- a/two.py
+++ b/two.py
@@ -195,7 +195,7 @@ class TwoBot:
                     await self.send_message(channelid, "No such user")
                 else:
                     await self.send_message(channelid, "%s has a total of %d" % (
-                        TwoBot.user_name(self.user_info(userid)),
+                        TwoBot.user_name(await self.user_info(userid)),
                         self.twoinfo["twos"].get(TwoBot.lower_id(userid), 0)))
         if len(parts) > 2:
             await self.send_message(


### PR DESCRIPTION
Due to a missing `await`, passing a username to `!two` caused the bot to crash. This PR resolves that issue.